### PR TITLE
added jobFilePath to printJob

### DIFF
--- a/OctoPrintAPI.cpp
+++ b/OctoPrintAPI.cpp
@@ -328,6 +328,7 @@ bool OctoprintApi::getPrintJob() {
       printJob.jobFileName   = (const char *)(root["job"]["file"]["name"] | "");
       printJob.jobFileOrigin = (const char *)(root["job"]["file"]["origin"] | "");
       printJob.jobFileSize   = root["job"]["file"]["size"];
+	  printJob.jobFilePath = (const char *)(root["job"]["file"]["path"] | "");
 
       printJob.jobFilamentTool0Length = root["job"]["filament"]["tool0"]["length"] | 0;
       printJob.jobFilamentTool0Volume = root["job"]["filament"]["tool0"]["volume"] | 0.0;

--- a/OctoPrintAPI.h
+++ b/OctoPrintAPI.h
@@ -62,6 +62,7 @@ struct printJobCall {
   String jobFileName;
   String jobFileOrigin;
   long jobFileSize;
+  String jobFilePath;
 
   float progressCompletion;
   long progressFilepos;

--- a/examples/ESP8266/GetPrintJobInfo/GetPrintJobInfo.ino
+++ b/examples/ESP8266/GetPrintJobInfo/GetPrintJobInfo.ino
@@ -89,6 +89,8 @@ void loop() {
         Serial.println(api.printJob.jobFileOrigin);
         Serial.print("jobFileSize (bytes) long:\t\t");
         Serial.println(api.printJob.jobFileSize);
+        Serial.print("jobFilePath:\t\t");
+        Serial.println(api.printJob.jobFilePath);
         Serial.print("jobFilamentTool0Length (mm) long:\t");
         Serial.println(api.printJob.jobFilamentTool0Length);
         Serial.print("jobFilamentTool0Volume (cm³) float:\t");


### PR DESCRIPTION
Added missing data point for printJobCall Struct.

jobFilePath

Updated examples where printJob is part of the example.

This makes it possible identify what folder/path a loaded job file is in.